### PR TITLE
feat: support multiple bindings in let expressions

### DIFF
--- a/crates/gnomon-db/src/eval.rs
+++ b/crates/gnomon-db/src/eval.rs
@@ -491,14 +491,35 @@ mod tests {
 
     // ── New expression forms ─────────────────────────────────────
 
-    // r[verify expr.let.scope]
-    // r[verify expr.let.syntax]
+    // r[verify expr.let.scope+2]
+    // r[verify expr.let.syntax+2]
     #[test]
     fn let_expression() {
         let db = Database::default();
         let result = eval(&db, r#"let x = 42 in { count: x }"#);
         let r = expect_record(&result);
         assert_eq!(get_field(r, &db, "count"), Value::Integer(42));
+    }
+
+    // r[verify expr.let.syntax+2]
+    // r[verify expr.let.scope+2]
+    #[test]
+    fn multi_binding_let_expression() {
+        let db = Database::default();
+        let result = eval(&db, r#"let x = 1 let y = 2 in { a: x, b: y }"#);
+        let r = expect_record(&result);
+        assert_eq!(get_field(r, &db, "a"), Value::Integer(1));
+        assert_eq!(get_field(r, &db, "b"), Value::Integer(2));
+    }
+
+    // r[verify expr.let.sequential]
+    // r[verify expr.let.scope+2]
+    #[test]
+    fn multi_binding_let_sequential() {
+        let db = Database::default();
+        // Each binding can reference earlier bindings.
+        let result = eval(&db, r#"let x = 1 let y = x let z = y in z"#);
+        assert_eq!(result.value, Value::Integer(1));
     }
 
     // r[verify expr.literal.identifier]

--- a/crates/gnomon-db/src/eval/lower.rs
+++ b/crates/gnomon-db/src/eval/lower.rs
@@ -326,7 +326,7 @@ impl<'db> LowerCtx<'db> {
                     Value::Undefined
                 }
             }
-            // r[impl expr.let.scope]
+            // r[impl expr.let.scope+2]
             // r[impl expr.let.sequential]
             ast::Expr::LetExpr(let_expr) => {
                 let name = let_expr

--- a/crates/gnomon-parser/src/lib.rs
+++ b/crates/gnomon-parser/src/lib.rs
@@ -1123,4 +1123,57 @@ task @cleanup "Clean""#;
             "chaining mixed comparisons should produce a parse error"
         );
     }
+
+    // ── Multi-binding let ────────────────────────────────────────
+
+    // r[verify expr.let.syntax+2]
+    #[test]
+    fn multi_binding_let_in_expr() {
+        // Inside an expression context, multi-binding let desugars to nested LET_EXPRs.
+        check(
+            "{ v: let x = 1 let y = 2 in x }",
+            expect![[r#"
+                SOURCE_FILE@0..31
+                  RECORD_EXPR@0..31
+                    L_BRACE@0..1 "{"
+                    WHITESPACE@1..2 " "
+                    FIELD@2..29
+                      IDENT@2..3 "v"
+                      COLON@3..4 ":"
+                      WHITESPACE@4..5 " "
+                      LET_EXPR@5..29
+                        LET_KW@5..8 "let"
+                        WHITESPACE@8..9 " "
+                        IDENT@9..10 "x"
+                        WHITESPACE@10..11 " "
+                        EQUALS@11..12 "="
+                        WHITESPACE@12..13 " "
+                        LITERAL_EXPR@13..14
+                          INTEGER_LITERAL@13..14 "1"
+                        WHITESPACE@14..15 " "
+                        LET_EXPR@15..29
+                          LET_KW@15..18 "let"
+                          WHITESPACE@18..19 " "
+                          IDENT@19..20 "y"
+                          WHITESPACE@20..21 " "
+                          EQUALS@21..22 "="
+                          WHITESPACE@22..23 " "
+                          LITERAL_EXPR@23..24
+                            INTEGER_LITERAL@23..24 "2"
+                          WHITESPACE@24..25 " "
+                          IN_KW@25..27 "in"
+                          WHITESPACE@27..28 " "
+                          IDENT_EXPR@28..29
+                            IDENT@28..29 "x"
+                    WHITESPACE@29..30 " "
+                    R_BRACE@30..31 "}"
+            "#]],
+        );
+    }
+
+    // r[verify expr.let.syntax+2]
+    #[test]
+    fn multi_binding_let_three_bindings_no_errors() {
+        check_no_errors("{ v: let a = 1 let b = 2 let c = 3 in a }");
+    }
 }

--- a/crates/gnomon-parser/src/parser/expr.rs
+++ b/crates/gnomon-parser/src/parser/expr.rs
@@ -210,16 +210,24 @@ impl Parser {
         self.finish_node();
     }
 
-    /// Parse a let expression: `let ident = expr in expr`
-    // r[impl expr.let.syntax]
+    /// Parse a let expression: `let ident = expr (let ... | in expr)`
+    ///
+    /// Multiple bindings desugar into nested `LET_EXPR` nodes:
+    /// `let x = 1 let y = 2 in body` → `LET_EXPR(x=1, LET_EXPR(y=2, body))`
+    // r[impl expr.let.syntax+2]
     fn parse_let_expr(&mut self) {
         self.start_node(SyntaxKind::LET_EXPR);
         self.bump_remap(SyntaxKind::LET_KW);
         self.expect(SyntaxKind::IDENT);
         self.expect(SyntaxKind::EQUALS);
         self.parse_expr();
-        self.expect_keyword("in", SyntaxKind::IN_KW);
-        self.parse_expr();
+        if self.at_keyword("let") {
+            // Multi-binding: next binding becomes the body (nested LET_EXPR).
+            self.parse_let_expr();
+        } else {
+            self.expect_keyword("in", SyntaxKind::IN_KW);
+            self.parse_expr();
+        }
         self.finish_node();
     }
 

--- a/spec/gnomon.md
+++ b/spec/gnomon.md
@@ -613,20 +613,21 @@ When writing a new cache entry, the implementation MUST remove any entries whose
 
 ### Let Expressions
 
-A `let` expression introduces a local binding that is in scope for the body expression. Let bindings are sequential: a binding may refer to earlier bindings but not to itself or later bindings.
+A `let` expression introduces one or more local bindings that are in scope for the body expression. Multiple bindings may appear before a single `in` keyword; each binding is introduced by its own `let` keyword. Multiple bindings desugar into nested single-binding let expressions.
 
-> r[expr.let.syntax]
+> r[expr.let.syntax+2]
 > The grammar for let expressions is as follows:
 >
 > ```ebnf
-> let expr = "let", identifier, "=", expr, "in", expr ;
+> let binding = "let", identifier, "=", expr ;
+> let expr = let binding, { let binding }, "in", expr ;
 > ```
 
 r[expr.let.sequential]
 Let bindings MUST be sequential: the bound expression may reference variables from enclosing or preceding `let` bindings, but MUST NOT reference the variable being bound or any later bindings.
 
-r[expr.let.scope]
-The variable introduced by a `let` binding MUST be in scope for the body expression (the expression after `in`).
+r[expr.let.scope+2]
+Each variable introduced by a `let` binding MUST be in scope for all subsequent bindings and for the body expression (the expression after `in`).
 
 ### Operator Precedence and Associativity
 


### PR DESCRIPTION
## Summary
- Extends `let` expression grammar to allow multiple bindings before a single `in`: `let x = 1 let y = 2 in body`
- Parser desugars into nested `LET_EXPR` nodes, requiring no changes to AST, evaluator, or validation
- Updates spec (`r[expr.let.syntax+2]`, `r[expr.let.scope+2]`) with new EBNF grammar

## Test plan
- [x] Parser test: multi-binding let inside expression context produces nested `LET_EXPR` CST
- [x] Parser test: three-binding let parses without errors
- [x] Eval test: `let x = 1 let y = 2 in { a: x, b: y }` produces correct record
- [x] Eval test: sequential bindings (`let x = 1 let y = x let z = y in z`) resolve correctly
- [x] Full workspace test suite passes (469 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)