### PR TITLE
fix: add symlink cycle detection to find_gnomon_files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -468,17 +468,33 @@ fn main() -> ExitCode {
 /// Recursively find all .gnomon files under a directory.
 fn find_gnomon_files(dir: &std::path::Path) -> Vec<PathBuf> {
     let mut result = Vec::new();
+    let mut visited = HashSet::new();
+    find_gnomon_files_inner(dir, &mut result, &mut visited);
+    result
+}
+
+fn find_gnomon_files_inner(
+    dir: &std::path::Path,
+    result: &mut Vec<PathBuf>,
+    visited: &mut HashSet<PathBuf>,
+) {
+    let canon = match dir.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    if !visited.insert(canon) {
+        return; // Already visited — cycle detected
+    }
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.filter_map(|e| e.ok()) {
             let path = entry.path();
             if path.is_dir() {
-                result.extend(find_gnomon_files(&path));
+                find_gnomon_files_inner(&path, result, visited);
             } else if path.extension().is_some_and(|ext| ext == "gnomon") {
                 result.push(path);
             }
         }
     }
-    result
 }
 
 /// Print diagnostics to stderr. Returns true if any errors were found.


### PR DESCRIPTION
## Summary
- Fixes `find_gnomon_files` following symlinks without cycle detection, which could cause infinite recursion and a stack overflow when symlink loops exist (e.g. `a -> b -> a`)
- Introduces a `find_gnomon_files_inner` helper that tracks visited directories via canonical paths in a `HashSet`, skipping any directory already seen
- The public `find_gnomon_files` signature is unchanged; the `HashSet` is managed internally

## Test plan
- [x] `cargo test --workspace` passes (all 455 tests)
- [x] Manual: create a symlink loop in a project directory and run `gnomon check` to verify it no longer hangs

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)