### PR TITLE
fix: accurate day count in datetime_to_total_seconds

### DIFF
--- a/crates/gnomon-import/src/lib.rs
+++ b/crates/gnomon-import/src/lib.rs
@@ -2194,10 +2194,7 @@ END:VCALENDAR\r\n";
     #[test]
     fn days_from_civil_known_values() {
         // Consecutive days differ by 1.
-        assert_eq!(
-            days_from_civil(2000, 3, 2) - days_from_civil(2000, 3, 1),
-            1
-        );
+        assert_eq!(days_from_civil(2000, 3, 2) - days_from_civil(2000, 3, 1), 1);
         // 1970-01-01 to 2000-03-01 = 11017 days.
         assert_eq!(
             days_from_civil(2000, 3, 1) - days_from_civil(1970, 1, 1),


### PR DESCRIPTION
## Summary
- Replaced the inaccurate `m * 30` month approximation in `datetime_to_total_seconds` with the exact `days_from_civil` algorithm from [Howard Hinnant's date algorithms](https://howardhinnant.github.io/date_algorithms.html), which correctly accounts for varying month lengths and leap years.
- Fixed `compute_duration_from_endpoints` to decompose the duration into days/hours/minutes/seconds instead of collapsing everything into hours with `days: 0`.
- Added 5 new tests: `days_from_civil_known_values`, `days_from_civil_month_lengths`, `duration_across_month_boundary_non_leap`, `duration_across_month_boundary_leap_year`, and `duration_multi_day_with_time`.

Closes #11

## Test plan
- [x] `days_from_civil` unit tests verify correct day counts for consecutive days, Unix epoch distance, leap year lengths, and non-leap year lengths
- [x] `days_from_civil` month-length tests verify January=31d, February non-leap=28d, February leap=29d
- [x] End-to-end iCal import test: Jan 31 to Mar 1 in non-leap year = 29 days (not 30)
- [x] End-to-end iCal import test: Jan 31 to Mar 1 in leap year = 30 days
- [x] End-to-end iCal import test: multi-day event with time correctly decomposes into 1d 19h 30m
- [x] Full workspace test suite passes (506 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)